### PR TITLE
Add test and parallelize test runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,14 +59,17 @@ yelp-production.s3-us-west-1.amazonaws.com
 (Compatibility has been tested with Python 2.7 and 3.6)
 
 ## Contributing
-Issues are welcome and Pull Requests are appreciated.
+Issues are welcome and Pull Requests are appreciated. All contributions should be compatible with both Python 2.7 and 3.6.
 
 |    master    |    [![Build Status](https://travis-ci.org/sa7mon/S3Scanner.svg?branch=master)](https://travis-ci.org/sa7mon/S3Scanner)    |
 |:------------:|:-------------------------------------------------------------------------------------------------------------------------:|
 | enhancements | [![Build Status](https://travis-ci.org/sa7mon/S3Scanner.svg?branch=enhancements)](https://travis-ci.org/sa7mon/S3Scanner) |
 |     bugs     |     [![Build Status](https://travis-ci.org/sa7mon/S3Scanner.svg?branch=bugs)](https://travis-ci.org/sa7mon/S3Scanner)     |
 
-All contributions should be compatiable with both Python 2.7 and 3.6. Run tests with `pytest` in 2.7 and 3.6 virtual environments.
+### Testing
+* All test are currently in `test_scanner.py`
+* Run tests with in 2.7 and 3.6 virtual environments.
+* This project uses **pytest-xdist** to run tests. Use `pytest -n NUM` where num is number of parallel processes.
 
 ## License
 Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International [(CC BY-NC-SA 4.0)](https://creativecommons.org/licenses/by-nc-sa/4.0/)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ argparse
 requests
 awscli
 sh
-pytest
+pytest-xdist
 coloredlogs

--- a/s3utils.py
+++ b/s3utils.py
@@ -3,6 +3,9 @@ import requests
 import os
 
 
+sizeCheckTimeout = 8    # How long to wait for getBucketSize to return
+
+
 def checkBucket(bucketName, region):
     """ Does a simple GET request with the Requests library and interprets the results.
 
@@ -60,7 +63,7 @@ def getBucketSize(bucketName):
     """
     try:
         a = sh.aws('s3', 'ls', '--summarize', '--human-readable', '--recursive', '--no-sign-request', 's3://' +
-                   bucketName, _timeout=8)
+                   bucketName, _timeout=sizeCheckTimeout)
     except sh.TimeoutException:
         return "Unknown Size"
     # Get the last line of the output, get everything to the right of the colon, and strip whitespace

--- a/test_scanner.py
+++ b/test_scanner.py
@@ -3,6 +3,7 @@ import sh
 import os
 import sys
 import shutil
+import time
 
 pyVersion = sys.version_info
 # pyVersion[0] can be 2 or 3
@@ -140,6 +141,26 @@ def test_getBucketSize():
 
     # Scenario 3
     assert s3.getBucketSize('flaws.cloud') == "9.1 KiB"
+
+
+def test_getBucketSizeTimeout():
+    """
+    Verify that dumpBucket() times out after X amount of seconds on buckets with many files.
+
+    Expected:
+        Use e27.co to test with. Verify that getBucketSize returns an unknown size and doesn't take longer
+        than sizeCheckTimeout set in s3utils
+    """
+
+    startTime = time.time()
+
+    output = s3.getBucketSize("e27.co")
+    duration = time.time() - startTime
+
+    # Assert that getting the bucket size took less than or equal to the alloted time plus 1 second to account
+    # for processing time.
+    assert duration <= s3.sizeCheckTimeout + 1
+    assert output == "Unknown Size"
 
 
 def test_outputFormat():


### PR DESCRIPTION
* Tests now use `pytest-xdist` to run tests in parallel
* Added a test to verify the timeout functionality of getBucketSize is correct
