### PR TITLE
Update s3scanner.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,4 +129,4 @@ Issues are welcome and Pull Requests are appreciated. All contributions should b
 * [janmasarik](https://github.com/janmasarik)
 
 ## License
-License: MIT https://opensource.org/licenses/MIT
+License: [MIT](LICENSE.txt) https://opensource.org/licenses/MIT

--- a/README.md
+++ b/README.md
@@ -13,18 +13,22 @@ A tool to find open S3 buckets and dump their contents :droplet:
 ## Usage
 
 <pre>
+usage: s3scanner [-h] [-o OUTFILE] [-d] [-l] [--version] buckets
+
 #  s3scanner - Find S3 buckets and dump!
 #
 #  Author: Dan Salmon - @bltjetpack, github.com/sa7mon
 
 positional arguments:
-  buckets                Name of text file containing buckets to check
+  buckets               Name of text file containing buckets to check
 
 optional arguments:
-  -h, --help              show this help message and exit
-  -o, --out-file OUTFILE  Name of file to save the successfully checked buckets in (Default: buckets.txt)
-  -d, --dump              Dump all found open buckets locally
-  -l, --list              List all found open buckets locally
+  -h, --help            show this help message and exit
+  -o OUTFILE, --out-file OUTFILE
+                        Name of file to save the successfully checked buckets in (Default: buckets.txt)
+  -d, --dump            Dump all found open buckets locally
+  -l, --list            Save bucket file listing to local file: ./list-buckets/${bucket}.txt
+  --version             Display the current version of this tool
 </pre>
 
 The tool takes in a list of bucket names to check. Found S3 buckets are output to file. The tool will also dump or list the contents of 'open' buckets locally.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-argparse
 awscli
 sh
 pytest-xdist

--- a/s3scanner.py
+++ b/s3scanner.py
@@ -9,11 +9,13 @@
 #########
 
 import argparse
-import s3utils as s3
 import logging
-import coloredlogs
+from os import path
 import sys
-import os.path
+
+import coloredlogs
+
+import s3utils as s3
 
 CURRENT_VERSION = '1.0.0'
 
@@ -86,7 +88,7 @@ if not s3.checkAwsCreds():
     slog.error("Warning: AWS credentials not configured. Open buckets will be shown as closed. Run:"
                " `aws configure` to fix this.\n")
 
-if os.path.isfile(args.buckets):
+if path.isfile(args.buckets):
     with open(args.buckets, 'r') as f:
         for line in f:
             line = line.rstrip()            # Remove any extra whitespace

--- a/s3scanner.py
+++ b/s3scanner.py
@@ -15,7 +15,7 @@ import coloredlogs
 import sys
 import os.path
 
-currentVersion = '1.0.0'
+CURRENT_VERSION = '1.0.0'
 
 
 
@@ -31,30 +31,17 @@ parser = argparse.ArgumentParser(description='#  s3scanner - Find S3 buckets and
                                  prog='s3scanner', formatter_class=CustomFormatter)
 
 # Declare arguments
-parser.add_argument('-o', '--out-file', required=False, dest='outFile',
+parser.add_argument('-o', '--out-file', dest='outFile', default='./buckets.txt',
                     help='Name of file to save the successfully checked buckets in (Default: buckets.txt)')
-# parser.add_argument('-c', '--include-closed', required=False, dest='includeClosed', action='store_true',
+# parser.add_argument('-c', '--include-closed', dest='includeClosed', action='store_true', default=False,
 #                     help='Include found but closed buckets in the out-file')
-parser.add_argument('-d', '--dump', required=False, dest='dump', action='store_true',
+parser.add_argument('-d', '--dump', dest='dump', action='store_true', default=False,
                     help='Dump all found open buckets locally')
-parser.add_argument('-l', '--list', required=False, dest='list', action='store_true',
+parser.add_argument('-l', '--list', dest='list', action='store_true',
                     help='Save bucket file listing to local file: ./list-buckets/${bucket}.txt')
-parser.add_argument('--version', required=False, dest='version', action='store_true',
+parser.add_argument('--version', action='version', version=CURRENT_VERSION,
                     help='Display the current version of this tool')
 parser.add_argument('buckets', help='Name of text file containing buckets to check')
-
-# parser.set_defaults(includeClosed=False)
-parser.set_defaults(outFile='./buckets.txt')
-parser.set_defaults(dump=False)
-
-
-if len(sys.argv) == 1:              # No args supplied, print the full help text instead of the short usage text
-    parser.print_help()
-    sys.exit(0)
-elif len(sys.argv) == 2:
-    if sys.argv[1] == '--version':  # Only --version arg supplied. Print the version and exit.
-        print(currentVersion)
-        sys.exit(0)
 
 
 # Parse the args

--- a/s3utils.py
+++ b/s3utils.py
@@ -123,11 +123,12 @@ def checkBucketName(bucket_name):
     :return: Boolean - whether or not the name is valid
     """
 
-    if len(bucket_name) < 3 or len(bucket_name) > 63:  # Bucket names can be 3-63 (inclusively) characters long.
-        return False
-
+    # Bucket names can be 3-63 (inclusively) characters long.
     # Bucket names may only contain lowercase letters, numbers, periods, and hyphens
-    return not bool(re.match(r'[^a-z0-9.-]', bucket_name))
+    pattern = r'(?=^.{3,63}$)(?!^(\d+\.)+\d+$)(^(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])$)'
+
+    
+    return bool(re.match(pattern, bucket_name))
 
 
 def checkBucketWithoutCreds(bucketName, triesLeft=2):

--- a/s3utils.py
+++ b/s3utils.py
@@ -1,13 +1,13 @@
 import sh
 import os
+
 import boto3
+from botocore.exceptions import ClientError
 import requests
 
 sizeCheckTimeout = 8    # How long to wait for getBucketSize to return
 awsCredsConfigured = True
 errorCodes = ['AccessDenied', 'AllAccessDisabled', '[Errno 21] Is a directory:']
-
-client = boto3.client('s3')
 
 
 def checkAcl(bucket):
@@ -29,10 +29,10 @@ def checkAcl(bucket):
     try:
         bucket_acl = s3.BucketAcl(bucket)
         bucket_acl.load()
-    except client.exceptions.NoSuchBucket:
+    except s3.meta.client.exceptions.NoSuchBucket:
         return {"found": False, "acls": {}}
 
-    except client.exceptions.ClientError as e:
+    except ClientError as e:
         if e.response['Error']['Code'] == "AccessDenied":
             return {"found": True, "acls": "AccessDenied"}
         elif e.response['Error']['Code'] == "AllAccessDisabled":

--- a/test_scanner.py
+++ b/test_scanner.py
@@ -280,39 +280,6 @@ def test_checkBucketWithoutCreds():
     assert s3.checkBucketWithoutCreds('blog') is True
 
 
-# def test_checkIncludeClosed():
-#     """ Verify that the '--include-closed' argument is working correctly.
-#         Expected:
-#             The bucket name 'yahoo.com' is expected to exist, but be closed. The bucket name
-#             and region should be included in the output buckets file in the format 'bucket:region'.
-#     """
-#     test_setup()
-#
-#     # Create a file called testing.txt and write 'yahoo.com' to it
-#
-#     inFile = testingFolder + 'test_checkIncludeClosed_in.txt'
-#     outFile = testingFolder + 'test_checkIncludeClosed_out.txt'
-#
-#     f = open(inFile, 'w')
-#     f.write('yahoo.com\n')  # python will convert \n to os.linesep
-#     f.close()
-#
-#     sh.python(s3scannerLocation + "s3scanner.py", "--out-file", outFile, "--include-closed", inFile)
-#
-#     found = False
-#     with open(outFile, 'r') as g:
-#         for line in g:
-#             if 'yahoo.com' in line:
-#                 found = True
-#
-#     try:
-#         assert found is True
-#     finally:
-#         # Cleanup testing files
-#         os.remove(outFile)
-#         os.remove(inFile)
-
-
 def test_dumpBucket():
     """
     Scenario dumpBucket.1 - Public read permission enabled
@@ -394,7 +361,7 @@ def test_getBucketSizeTimeout():
 
     # Assert that getting the bucket size took less than or equal to the alloted time plus 1 second to account
     # for processing time.
-    assert duration <= s3.sizeCheckTimeout + 1
+    assert duration <= s3.SIZE_CHECK_TIMEOUT + 1
     assert output == "Unknown Size - timeout"
 
 


### PR DESCRIPTION
-flags are optional by default, so calling `required=False` is unneeded
-You can `default` while calling `add_argument`. No need to call `set_defaults` on the side
-added the correct way for `argparse` to handle `--version`