### PR TITLE
Fix not creating file listing even if access available

### DIFF
--- a/s3utils.py
+++ b/s3utils.py
@@ -109,7 +109,7 @@ def checkBucket(inBucket, slog, flog, argsDump, argsList):
                 slog.info("{0:>11} : {1} - {2}".format("[found]", bucket, "Attempting to dump...this may take a while."))
                 dumpBucket(bucket)
         if argsList:
-            if str(b["acls"]) not in ["AccessDenied", "AllAccessDisabled"]:
+            if str(b["acls"]) not in ["AllAccessDisabled"]:
                 listBucket(bucket)
     else:
         message = "{0:>11} : {1}".format("[not found]", bucket)


### PR DESCRIPTION
Removing check for "AccessDenied" because it was preventing creating the file listing - even when access was possible.