### PR TITLE
Fix path traversal bug

### DIFF
--- a/S3Scanner/S3Service.py
+++ b/S3Scanner/S3Service.py
@@ -293,13 +293,13 @@ class S3Service:
         """
         Download `obj` from `bucket` into `dest_directory`
 
-        :param str dest_directory: Directory to store the object into
+        :param str dest_directory: Directory to store the object into. _Must_ end in a slash
         :param S3Bucket bucket: Bucket to download the object from
         :param bool verbose: Output verbose messages to the user
         :param S3BucketObject obj: Object to downlaod
         :return: None
         """
-        dest_file_path = pathlib.Path(os.path.normpath(dest_directory + obj.key))
+        dest_file_path = pathlib.Path(os.path.normpath(os.path.join(dest_directory, obj.key)))
 
         if not self.is_safe_file_to_download(obj.key, dest_directory):
             print(f"{bucket.name} | Skipping file {obj.key}. File references a parent directory.")

--- a/S3Scanner/__main__.py
+++ b/S3Scanner/__main__.py
@@ -16,7 +16,7 @@ from .S3Service import S3Service
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from .exceptions import InvalidEndpointException
 
-CURRENT_VERSION = '2.0.1'
+CURRENT_VERSION = '2.0.2'
 AWS_ENDPOINT = 'https://s3.amazonaws.com'
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = S3Scanner
-version = 2.0.1
+version = 2.0.2
 author = Dan Salmon
 author_email = dan@salmon.cat
 description = Scan for open S3 buckets and dump the contents

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -11,7 +11,7 @@ def test_arguments():
     s = S3Service()
 
     a = subprocess.run([sys.executable, '-m', 'S3Scanner', '--version'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    assert a.stdout.decode('utf-8').strip() == '2.0.1'
+    assert a.stdout.decode('utf-8').strip() == '2.0.2'
 
     b = subprocess.run([sys.executable, '-m', 'S3Scanner', 'scan', '--bucket', 'flaws.cloud'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     assert_scanner_output(s, 'flaws.cloud | bucket_exists | AuthUsers: [], AllUsers: [Read]', b.stdout.decode('utf-8').strip())

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -545,6 +545,19 @@ def test_download_file():
     b = S3Bucket("bucket-no-existo")
     s.download_file(os.path.join(dest_folder, ''), b, True, o)
 
+def test_is_safe_file_to_download():
+    test_setup_new()
+    s = S3Service()
+
+    # Check a good file name
+    assert s.is_safe_file_to_download("file.txt", "./bucket_dir/") == True
+    assert s.is_safe_file_to_download("file.txt", "./bucket_dir") == True
+
+    # Check file with relative name
+    assert s.is_safe_file_to_download("../file.txt", "./buckets/") == False
+    assert s.is_safe_file_to_download("../", "./buckets/") == False
+    assert s.is_safe_file_to_download("/file.txt", "./buckets/") == False
+
 
 def test_validate_endpoint_url_nonaws():
     disable_warnings()


### PR DESCRIPTION
Fixes #122 by adding `is_safe_file_to_download()`. This method compares the full resolved path of the file to be downloaded against the folder it should be saved into to verify the file will end up inside the folder. If not, the file is skipped and the user is informed.