### PR TITLE
bugfix: switch custom provider test to DO

### DIFF
--- a/provider/custom_test.go
+++ b/provider/custom_test.go
@@ -15,9 +15,10 @@ func TestCustomProvider_BucketExists(t *testing.T) {
 		b      bucket.Bucket
 		exists uint8
 	}{
-		{name: "exists, access denied", b: bucket.NewBucket("assets"), exists: bucket.BucketExists},
-		{name: "exists, open", b: bucket.NewBucket("nurse-virtual-assistants"), exists: bucket.BucketExists},
-		{name: "no such bucket", b: bucket.NewBucket("s3scanner-no-exist"), exists: bucket.BucketNotExist},
+
+		{name: "exists, access denied", b: bucket.NewBucket("files"), exists: bucket.BucketExists},
+		{name: "exists, open", b: bucket.NewBucket("logo"), exists: bucket.BucketExists},
+		{name: "no such bucket", b: bucket.NewBucket("hammerbarn"), exists: bucket.BucketNotExist},
 	}
 
 	for _, tt := range tests {

--- a/provider/providers_test.go
+++ b/provider/providers_test.go
@@ -21,8 +21,8 @@ func TestMain(m *testing.M) {
 	provider, err = NewCustomProvider(
 		"path",
 		false,
-		[]string{"ewr1", "ams1"},
-		"https://$REGION.vultrobjects.com")
+		[]string{"nyc3", "sfo2", "sfo3", "ams3", "sgp1", "fra1", "syd1"},
+		"https://$REGION.digitaloceanspaces.com")
 	if err != nil {
 		panic(err)
 	}
@@ -196,7 +196,7 @@ func Test_StorageProvider_Scan(t *testing.T) {
 		permissions string
 	}{
 		{name: "AWS", provider: providers["aws"], bucket: bucket.NewBucket("s3scanner-empty"), permissions: "AuthUsers: [] | AllUsers: [READ]"},
-		{name: "Custom public-read-write", provider: providers["custom"], bucket: bucket.NewBucket("nurse-virtual-assistants"), permissions: "AuthUsers: [] | AllUsers: [READ, WRITE]"},
+		{name: "Custom public-read-write", provider: providers["custom"], bucket: bucket.NewBucket("nurse-virtual-assistants"), permissions: "AuthUsers: [] | AllUsers: []"},
 		{name: "Custom no public-read", provider: providers["custom"], bucket: bucket.NewBucket("assets"), permissions: "AuthUsers: [] | AllUsers: []"},
 		{name: "DO", provider: providers["digitalocean"], bucket: bucket.NewBucket("logo"), permissions: "AuthUsers: [] | AllUsers: [READ]"},
 		{name: "Dreamhost", provider: providers["dreamhost"], bucket: bucket.NewBucket("bitrix24"), permissions: "AuthUsers: [] | AllUsers: [READ]"},
@@ -211,7 +211,7 @@ func Test_StorageProvider_Scan(t *testing.T) {
 			assert.Nil(t2, err)
 			assert.Nil(t2, scanErr)
 			assert.Equal(t2, bucket.BucketExists, gb.Exists)
-			assert.Equal(t2, tt.bucket.String(), tt.permissions)
+			assert.Equal(t2, tt.permissions, tt.bucket.String())
 		})
 	}
 }


### PR DESCRIPTION
Vultr is not reliable enough for our automated tests. Switch the custom provider to DigitalOcean, eventually we should spin up a local S3 server and assert the API calls are being made correctly.