### PR TITLE
Make region-client map concurrency safe

### DIFF
--- a/provider/clientmap/clientmap.go
+++ b/provider/clientmap/clientmap.go
@@ -1,0 +1,54 @@
+package clientmap
+
+import (
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"sync"
+)
+
+type ClientMap struct {
+	sync.Mutex
+	inner map[string]*s3.Client
+}
+
+func New() *ClientMap {
+	return &ClientMap{
+		Mutex: sync.Mutex{},
+		inner: make(map[string]*s3.Client),
+	}
+}
+
+func WithCapacity(cap int) *ClientMap {
+	return &ClientMap{
+		Mutex: sync.Mutex{},
+		inner: make(map[string]*s3.Client, cap),
+	}
+}
+
+func (m *ClientMap) Get(key string) *s3.Client {
+	m.Lock()
+	defer m.Unlock()
+	if v, ok := m.inner[key]; ok {
+		return v
+	}
+	return nil
+}
+
+func (m *ClientMap) Set(key string, value *s3.Client) {
+	m.Lock()
+	m.inner[key] = value
+	m.Unlock()
+}
+
+func (m *ClientMap) Len() int {
+	m.Lock()
+	defer m.Unlock()
+	return len(m.inner)
+}
+
+func (m *ClientMap) Each(fn func(region string, client *s3.Client)) {
+	m.Lock()
+	for region, client := range m.inner {
+		fn(region, client)
+	}
+	m.Unlock()
+}

--- a/provider/digitalocean.go
+++ b/provider/digitalocean.go
@@ -3,13 +3,15 @@ package provider
 import (
 	"errors"
 	"fmt"
+
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/sa7mon/s3scanner/bucket"
+	"github.com/sa7mon/s3scanner/provider/clientmap"
 )
 
 type providerDO struct {
 	regions []string
-	clients map[string]*s3.Client
+	clients *clientmap.ClientMap
 }
 
 func (pdo providerDO) Insecure() bool {
@@ -66,25 +68,21 @@ func (pdo *providerDO) Regions() []string {
 	return urls
 }
 
-func (pdo *providerDO) newClients() (map[string]*s3.Client, error) {
-	clients := make(map[string]*s3.Client, len(pdo.regions))
+func (pdo *providerDO) newClients() (*clientmap.ClientMap, error) {
+	clients := clientmap.WithCapacity(len(pdo.regions))
 	for _, r := range pdo.Regions() {
 		client, err := newNonAWSClient(pdo, r)
 		if err != nil {
 			return nil, err
 		}
-		clients[r] = client
+		clients.Set(r, client)
 	}
 
 	return clients, nil
 }
 
 func (pdo *providerDO) getRegionClient(region string) *s3.Client {
-	c, ok := pdo.clients[region]
-	if ok {
-		return c
-	}
-	return nil
+	return pdo.clients.Get(region)
 }
 
 func NewProviderDO() (*providerDO, error) {

--- a/provider/gcp.go
+++ b/provider/gcp.go
@@ -2,8 +2,10 @@ package provider
 
 import (
 	"errors"
+
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/sa7mon/s3scanner/bucket"
+	"github.com/sa7mon/s3scanner/provider/clientmap"
 )
 
 // GCP like AWS, has a "universal" endpoint, but unlike AWS GCP does not require you to follow a redirect to the
@@ -30,7 +32,9 @@ func (g GCP) BucketExists(b *bucket.Bucket) (*bucket.Bucket, error) {
 	if !bucket.IsValidS3BucketName(b.Name) {
 		return nil, errors.New("invalid bucket name")
 	}
-	exists, region, err := bucketExists(map[string]*s3.Client{"default": g.client}, b)
+	clients := clientmap.New()
+	clients.Set("default", g.client)
+	exists, region, err := bucketExists(clients, b)
 	if err != nil {
 		return b, err
 	}


### PR DESCRIPTION
### Changes
- A custom client map data structure is created as a sub-package under providers
- The client map structure uses a mutex for synchronization
- All concurrency unsafe `map[string]*s3.Client` instances are replaced with the custom structure
- The structure can be created using `clientmap.New()` or `clientmap.WithCapacity(int)`
- Key-value pairs can be retrieved or set using the `Get` and `Set` methods respectively
- Bare range over the structure is unavailable; hence we use a `for i := ...` loop over the length using the `Len()` method