### PR TITLE
feat: deduplicate bucket names when ingesting from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ assets
 image-uploads
 ```
 
+Bucket names listed multiple times will only be scanned once.
+
 *`-mq`*
 -------
 


### PR DESCRIPTION
Fixes #156

### Changes
- Adds a string hashset (empty struct map) to keep track of bucket names that are already seen
- Continues the file scanning loop if a bucket name is seen
- Sends the bucket to the channel and adds it to the set of seen bucket names otherwise