### PR TITLE
feat: add scaleway support

### DIFF
--- a/cmd/regioncheck/regioncheck.go
+++ b/cmd/regioncheck/regioncheck.go
@@ -5,6 +5,7 @@ import (
 	"github.com/PuerkitoBio/goquery"
 	"github.com/sa7mon/s3scanner/collection"
 	"github.com/sa7mon/s3scanner/provider"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -145,31 +146,57 @@ func GetRegionsDreamhost() ([]string, error) {
 		if cerr == nil {
 			resolvableRegions = append(resolvableRegions, s)
 		}
-
 	}
 
 	return resolvableRegions, nil
 }
 
-func main() {
-	wg := sync.WaitGroup{}
-	wg.Add(3)
+func GetRegionsScaleway() ([]string, error) {
+	var re = regexp.MustCompile(`Region: \x60(.+)\x60`)
+	requestURL := "https://raw.githubusercontent.com/scaleway/docs-content/main/storage/object/how-to/create-a-bucket.mdx"
+	res, err := http.Get(requestURL)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode != 200 {
+		return nil, fmt.Errorf("status code error: %d %s", res.StatusCode, res.Status)
+	}
 
+	bytes, bErr := io.ReadAll(res.Body)
+	if bErr != nil {
+		return nil, bErr
+	}
+
+	var regions []string
+	for _, a := range re.FindAllSubmatch(bytes, -1) {
+		regions = append(regions, string(a[1]))
+	}
+	return regions, nil
+}
+
+func main() {
 	results := map[string][]string{}
 	errors := map[string]error{}
 
-	go func(w *sync.WaitGroup) {
-		results["digitalocean"], errors["digitalocean"] = GetRegionsDO()
-		wg.Done()
-	}(&wg)
-	go func(w *sync.WaitGroup) {
-		results["dreamhost"], errors["dreamhost"] = GetRegionsDreamhost()
-		wg.Done()
-	}(&wg)
-	go func(w *sync.WaitGroup) {
-		results["linode"], errors["linode"] = GetRegionsLinode()
-		wg.Done()
-	}(&wg)
+	p := map[string]func() ([]string, error){
+		"digitalocean": GetRegionsDO,
+		"dreamhost":    GetRegionsDreamhost,
+		"linode":       GetRegionsLinode,
+		"scaleway":     GetRegionsScaleway,
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(len(p))
+
+	for name, get := range p {
+		name := name
+		get := get
+		go func(w *sync.WaitGroup) {
+			results[name], errors[name] = get()
+			wg.Done()
+		}(&wg)
+	}
 	wg.Wait()
 
 	exit := 0
@@ -187,7 +214,7 @@ func main() {
 			log.Printf("[%s] regions differ! Existing: %v, found: %v", p, knownRegions, foundRegions)
 			exit = 1
 		} else {
-			log.Printf("[%s} OK", p)
+			log.Printf("[%s] OK", p)
 		}
 	}
 	os.Exit(exit)

--- a/cmd/regioncheck/regioncheck_test.go
+++ b/cmd/regioncheck/regioncheck_test.go
@@ -19,9 +19,9 @@ func TestGetRegionsLinode(t *testing.T) {
 	assert.Contains(t, r, "us-east-1")
 }
 
-func TestGetRegionsDreamhost(t *testing.T) {
-	dor, err := GetRegionsDreamhost()
+func TestGetRegionsScaleway(t *testing.T) {
+	r, err := GetRegionsScaleway()
 	assert.Nil(t, err)
-	assert.GreaterOrEqual(t, len(dor), 1)
-	assert.Contains(t, dor, "us-east-1")
+	assert.GreaterOrEqual(t, len(r), 1)
+	assert.Contains(t, r, "fr-par")
 }

--- a/provider/providers_test.go
+++ b/provider/providers_test.go
@@ -52,6 +52,12 @@ func TestMain(m *testing.M) {
 	}
 	providers["linode"] = provider
 
+	provider, err = NewProviderScaleway()
+	if err != nil {
+		panic(err)
+	}
+	providers["scaleway"] = provider
+
 	code := m.Run()
 	os.Exit(code)
 }
@@ -114,6 +120,7 @@ func Test_StorageProvider_Statics(t *testing.T) {
 		{name: "Dreamhost", provider: providers["dreamhost"], insecure: false, addressStyle: PathStyle},
 		{name: "GCP", provider: providers["gcp"], insecure: false, addressStyle: PathStyle},
 		{name: "Linode", provider: providers["linode"], insecure: false, addressStyle: VirtualHostStyle},
+		{name: "Scaleway", provider: providers["scaleway"], insecure: false, addressStyle: PathStyle},
 	}
 
 	for _, tt := range tests {
@@ -135,9 +142,10 @@ func Test_StorageProvider_BucketExists(t *testing.T) {
 	}{
 		{name: "AWS", provider: providers["aws"], goodBucket: bucket.NewBucket("s3scanner-empty"), badBucket: bucket.NewBucket("s3scanner-no-exist")},
 		{name: "DO", provider: providers["digitalocean"], goodBucket: bucket.NewBucket("logo"), badBucket: bucket.NewBucket("s3scanner-no-exist")},
-		{name: "Dreamhost", provider: providers["dreamhost"], goodBucket: bucket.NewBucket("assets"), badBucket: bucket.NewBucket("s3scanner-no-exist")},
+		{name: "Dreamhost", provider: providers["dreamhost"], goodBucket: bucket.NewBucket("bitrix24"), badBucket: bucket.NewBucket("s3scanner-no-exist")},
 		{name: "GCP", provider: providers["gcp"], goodBucket: bucket.NewBucket("books"), badBucket: bucket.NewBucket("s3scanner-no-exist")},
 		{name: "Linode", provider: providers["linode"], goodBucket: bucket.NewBucket("vantage"), badBucket: bucket.NewBucket("s3scanner-no-exist")},
+		{name: "Scaleway", provider: providers["scaleway"], goodBucket: bucket.NewBucket("2017"), badBucket: bucket.NewBucket("s3scanner-no-exist")},
 	}
 
 	for _, tt := range tests {
@@ -170,6 +178,7 @@ func Test_StorageProvider_Enum(t *testing.T) {
 		{name: "Dreamhost", provider: providers["dreamhost"], goodBucket: bucket.NewBucket("bitrix24"), numObjects: 6},
 		{name: "GCP", provider: providers["gcp"], goodBucket: bucket.NewBucket("assets"), numObjects: 3},
 		{name: "Linode", provider: providers["linode"], goodBucket: bucket.NewBucket("vantage"), numObjects: 47},
+		{name: "Scaleway", provider: providers["scaleway"], goodBucket: bucket.NewBucket("3d-builder"), numObjects: 1},
 	}
 
 	for _, tt := range tests {
@@ -202,6 +211,7 @@ func Test_StorageProvider_Scan(t *testing.T) {
 		{name: "Dreamhost", provider: providers["dreamhost"], bucket: bucket.NewBucket("bitrix24"), permissions: "AuthUsers: [] | AllUsers: [READ]"},
 		{name: "GCP", provider: providers["gcp"], bucket: bucket.NewBucket("hatrioua"), permissions: "AuthUsers: [] | AllUsers: []"},
 		{name: "Linode", provider: providers["linode"], bucket: bucket.NewBucket("vantage"), permissions: "AuthUsers: [] | AllUsers: [READ]"},
+		{name: "Scaleway", provider: providers["scaleway"], bucket: bucket.NewBucket("3d-builder"), permissions: "AuthUsers: [] | AllUsers: [READ]"},
 	}
 
 	for _, tt := range tests {

--- a/provider/scaleway.go
+++ b/provider/scaleway.go
@@ -1,0 +1,82 @@
+package provider
+
+import (
+	"errors"
+	"fmt"
+	"github.com/sa7mon/s3scanner/bucket"
+	"github.com/sa7mon/s3scanner/provider/clientmap"
+)
+
+type providerScaleway struct {
+	clients *clientmap.ClientMap
+}
+
+func NewProviderScaleway() (*providerScaleway, error) {
+	sc := new(providerScaleway)
+
+	clients, err := sc.newClients()
+	if err != nil {
+		return sc, err
+	}
+	sc.clients = clients
+	return sc, nil
+}
+
+func (sc *providerScaleway) newClients() (*clientmap.ClientMap, error) {
+	clients := clientmap.WithCapacity(len(ProviderRegions[sc.Name()]))
+	for _, r := range ProviderRegions[sc.Name()] {
+		client, err := newNonAWSClient(sc, fmt.Sprintf("https://s3.%s.scw.cloud", r))
+		if err != nil {
+			return nil, err
+		}
+		clients.Set(r, client)
+	}
+
+	return clients, nil
+}
+
+func (sc *providerScaleway) Scan(b *bucket.Bucket, doDestructiveChecks bool) error {
+	client := sc.clients.Get(b.Region)
+	return checkPermissions(client, b, doDestructiveChecks)
+}
+
+func (*providerScaleway) Insecure() bool {
+	return false
+}
+
+func (*providerScaleway) Name() string {
+	return "scaleway"
+}
+
+func (*providerScaleway) AddressStyle() int {
+	return PathStyle
+}
+
+func (sc *providerScaleway) BucketExists(b *bucket.Bucket) (*bucket.Bucket, error) {
+	b.Provider = sc.Name()
+	exists, region, err := bucketExists(sc.clients, b)
+	if err != nil {
+		return b, err
+	}
+	if exists {
+		b.Exists = bucket.BucketExists
+		b.Region = region
+	} else {
+		b.Exists = bucket.BucketNotExist
+	}
+
+	return b, nil
+}
+
+func (sc *providerScaleway) Enumerate(b *bucket.Bucket) error {
+	if b.Exists != bucket.BucketExists {
+		return errors.New("bucket might not exist")
+	}
+
+	client := sc.clients.Get(b.Region)
+	enumErr := enumerateListObjectsV2(client, b)
+	if enumErr != nil {
+		return enumErr
+	}
+	return nil
+}


### PR DESCRIPTION
## Changes

- Add support for scanning buckets in Scaleway
- Add region check to scan and parse the source of their [docs page](https://github.com/scaleway/docs-content/blob/main/storage/object/quickstart.mdx)

## Notes

While working on this, I learned a lot about what the `GetBucketRegion` call actually does and how we can improve the efficiency of checking if a bucket exists. Those notes have all been captured in #209. Additionally, [mitmproxy](https://mitmproxy.org/) was a huge help in debugging the API interactions. I will be adding it to the dev docker compose file to make future development easier.


Closes #206 