### PR TITLE
bugfix: remove dreamhost region check

### DIFF
--- a/cmd/regioncheck/regioncheck.go
+++ b/cmd/regioncheck/regioncheck.go
@@ -3,17 +3,13 @@ package main
 import (
 	"fmt"
 	"github.com/PuerkitoBio/goquery"
-	"github.com/sa7mon/s3scanner/collection"
 	"github.com/sa7mon/s3scanner/provider"
 	"log"
-	"net"
 	"net/http"
 	"os"
-	"regexp"
 	"sort"
 	"strings"
 	"sync"
-	"time"
 )
 
 // eq compares sorted string slices. Once we move to Golang 1.21, use slices.Equal instead.
@@ -104,56 +100,9 @@ func GetRegionsLinode() ([]string, error) {
 	return regions, nil
 }
 
-// GetRegionsDreamhost fetches subdomains of dream.io like 'objects-us-east-1.dream.io' via crt.sh since Dreamhost
-// doesn't have a documentation page listing the regions.
-func GetRegionsDreamhost() ([]string, error) {
-	var domainRe = regexp.MustCompile(`objects-([^\.]+)\.dream\.io`)
-	requestURL := "https://crt.sh/?q=.dream.io"
-	// Request the HTML page.
-	res, err := http.Get(requestURL)
-	if err != nil {
-		return nil, err
-	}
-	defer res.Body.Close()
-	if res.StatusCode != 200 {
-		return nil, fmt.Errorf("status code error: %d %s", res.StatusCode, res.Status)
-	}
-
-	// Load the HTML document
-	doc, err := goquery.NewDocumentFromReader(res.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	certCNs := collection.StringSet{}
-	// For each cell in the Common Name column
-	doc.Find("body > table table tbody tr > td:nth-of-type(5)").Each(func(i int, t *goquery.Selection) {
-		matches := domainRe.FindAllStringSubmatch(t.Text(), -1)
-		for _, match := range matches {
-			if !strings.HasPrefix(match[1], "website-") { // regions like 'objects-website-us-east-1' are not for Object Storage
-				certCNs.Add(match[1])
-			}
-		}
-	})
-
-	// crt.sh may return old or invalid SSL certs
-	// verify regions found resolve and respond on port 443
-	resolvableRegions := []string{}
-	for _, s := range certCNs.Slice() {
-		timeout := 1 * time.Second
-		_, cerr := net.DialTimeout("tcp", fmt.Sprintf("objects-%s.dream.io:443", s), timeout)
-		if cerr == nil {
-			resolvableRegions = append(resolvableRegions, s)
-		}
-
-	}
-
-	return resolvableRegions, nil
-}
-
 func main() {
 	wg := sync.WaitGroup{}
-	wg.Add(3)
+	wg.Add(2)
 
 	results := map[string][]string{}
 	errors := map[string]error{}
@@ -163,13 +112,13 @@ func main() {
 		wg.Done()
 	}(&wg)
 	go func(w *sync.WaitGroup) {
-		results["dreamhost"], errors["dreamhost"] = GetRegionsDreamhost()
-		wg.Done()
-	}(&wg)
-	go func(w *sync.WaitGroup) {
 		results["linode"], errors["linode"] = GetRegionsLinode()
 		wg.Done()
 	}(&wg)
+
+	// No region check for Dreamhost
+	results["dreamhost"] = provider.ProviderRegions["dreamhost"]
+
 	wg.Wait()
 
 	exit := 0

--- a/cmd/regioncheck/regioncheck_test.go
+++ b/cmd/regioncheck/regioncheck_test.go
@@ -18,10 +18,3 @@ func TestGetRegionsLinode(t *testing.T) {
 	assert.GreaterOrEqual(t, len(r), 1)
 	assert.Contains(t, r, "us-east-1")
 }
-
-func TestGetRegionsDreamhost(t *testing.T) {
-	dor, err := GetRegionsDreamhost()
-	assert.Nil(t, err)
-	assert.GreaterOrEqual(t, len(dor), 1)
-	assert.Contains(t, dor, "us-east-1")
-}

--- a/provider/providers_test.go
+++ b/provider/providers_test.go
@@ -135,7 +135,7 @@ func Test_StorageProvider_BucketExists(t *testing.T) {
 	}{
 		{name: "AWS", provider: providers["aws"], goodBucket: bucket.NewBucket("s3scanner-empty"), badBucket: bucket.NewBucket("s3scanner-no-exist")},
 		{name: "DO", provider: providers["digitalocean"], goodBucket: bucket.NewBucket("logo"), badBucket: bucket.NewBucket("s3scanner-no-exist")},
-		{name: "Dreamhost", provider: providers["dreamhost"], goodBucket: bucket.NewBucket("assets"), badBucket: bucket.NewBucket("s3scanner-no-exist")},
+		{name: "Dreamhost", provider: providers["dreamhost"], goodBucket: bucket.NewBucket("bitrix24"), badBucket: bucket.NewBucket("s3scanner-no-exist")},
 		{name: "GCP", provider: providers["gcp"], goodBucket: bucket.NewBucket("books"), badBucket: bucket.NewBucket("s3scanner-no-exist")},
 		{name: "Linode", provider: providers["linode"], goodBucket: bucket.NewBucket("vantage"), badBucket: bucket.NewBucket("s3scanner-no-exist")},
 	}


### PR DESCRIPTION
crt.sh doesn't appreciate us making requests from Github actions runners and it seems like Dreamhost only has one region (`us-east-1`) right now anyway. Will check back again in a while to see if they've added any new regions. If so, they hopefully will have added a docs page too listing them.