### PR TITLE
chore: ignore aws library patch releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,9 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "github.com/aws/aws-sdk-go-v2/*"
+        update-types: ["version-update:semver-patch"]
+    commit-message:
+      # Prefix all commit messages with "npm: "
+      prefix: "chore"


### PR DESCRIPTION
Only have dependabot create PRs if the new library version is a major or minor release. We don't care about patches.

Closes #196 