### PR TITLE
fix: regions, test buckets

### DIFF
--- a/cmd/regioncheck/digitalocean.go
+++ b/cmd/regioncheck/digitalocean.go
@@ -36,7 +36,7 @@ func GetRegionsDO() ([]string, error) {
 	doc.Find("h2#other-digitalocean-products + div table tbody tr").Each(func(_ int, t *goquery.Selection) {
 		// For each row, check the first cell for a value of "Spaces"
 		rowHeader := t.Find("td").First().Text()
-		if rowHeader == "Spaces" {
+		if rowHeader == "Spaces Standard Storage" {
 			// For each cell in the "Spaces" row, check if the contents are not empty - meaning Spaces is supported
 			t.Find("td").Each(func(i int, v *goquery.Selection) {
 				if v.Has("i.fa-circle").Length() != 0 {

--- a/cmd/regioncheck/linode.go
+++ b/cmd/regioncheck/linode.go
@@ -16,7 +16,7 @@ func GetRegionsLinode() ([]string, error) {
 	resp := req.
 		ImpersonateFirefox().
 		R().
-		MustGet("https://techdocs.akamai.com/cloud-computing/docs/object-storage-product-limits")
+		MustGet("https://techdocs.akamai.com/cloud-computing/docs/endpoint-types")
 
 	doc, err := goquery.NewDocumentFromReader(strings.NewReader(resp.String()))
 	if err != nil {
@@ -26,7 +26,7 @@ func GetRegionsLinode() ([]string, error) {
 	regionRe := regexp.MustCompile(`[\w-]+\.linodeobjects\.com`)
 
 	regions := []string{}
-	doc.Find(".rdmd-table:nth-of-type(1) tbody tr td:nth-of-type(4)").Each(func(_ int, t *goquery.Selection) {
+	doc.Find(".rdmd-table:nth-of-type(2) tbody tr td:nth-of-type(7)").Each(func(_ int, t *goquery.Selection) {
 		for _, r := range regionRe.FindAllString(t.Text(), -1) {
 			regions = append(regions, strings.ReplaceAll(r, ".linodeobjects.com", ""))
 		}

--- a/cmd/regioncheck/regioncheck_test.go
+++ b/cmd/regioncheck/regioncheck_test.go
@@ -23,6 +23,6 @@ func TestGetRegionsLinode(t *testing.T) {
 func TestGetRegionsScaleway(t *testing.T) {
 	r, err := GetRegionsScaleway()
 	assert.Nil(t, err)
-	assert.GreaterOrEqual(t, len(r), 3)
+	assert.Equal(t, 3, len(r))
 	assert.Contains(t, r, "fr-par")
 }

--- a/cmd/regioncheck/regioncheck_test.go
+++ b/cmd/regioncheck/regioncheck_test.go
@@ -16,7 +16,7 @@ func TestGetRegionsDO(t *testing.T) {
 func TestGetRegionsLinode(t *testing.T) {
 	r, err := GetRegionsLinode()
 	assert.Nil(t, err)
-	assert.GreaterOrEqual(t, len(r), 28)
+	assert.GreaterOrEqual(t, len(r), 25)
 	assert.Contains(t, r, "us-east-1")
 }
 

--- a/cmd/regioncheck/regioncheck_test.go
+++ b/cmd/regioncheck/regioncheck_test.go
@@ -9,7 +9,7 @@ import (
 func TestGetRegionsDO(t *testing.T) {
 	r, err := GetRegionsDO()
 	assert.Nil(t, err)
-	assert.Equal(t, 11, len(r))
+	assert.Equal(t, 12, len(r))
 	assert.Contains(t, r, "nyc3")
 }
 
@@ -23,6 +23,6 @@ func TestGetRegionsLinode(t *testing.T) {
 func TestGetRegionsScaleway(t *testing.T) {
 	r, err := GetRegionsScaleway()
 	assert.Nil(t, err)
-	assert.Equal(t, 3, len(r))
+	assert.Equal(t, 4, len(r))
 	assert.Contains(t, r, "fr-par")
 }

--- a/cmd/regioncheck/scaleway.go
+++ b/cmd/regioncheck/scaleway.go
@@ -1,15 +1,32 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
-	"regexp"
 )
 
+type ProductsResponse struct {
+	Products []Product `json:"products"`
+}
+
+type Product struct {
+	ProductCategory string `json:"product_category"`
+	ProductName     string `json:"product"`
+	Description     string `json:"description"`
+	Status          string `json:"status"`
+	Locality        struct {
+		Region string `json:"region"`
+	} `json:"locality"`
+}
+
+/*
+	    GetRegionsScaleway gets regions from the Scaleway API
+		Documentation: https://www.scaleway.com/en/developers/api/product-catalog/public-catalog-api/
+*/
 func GetRegionsScaleway() ([]string, error) {
-	var re = regexp.MustCompile(`Region: \x60(.+)\x60`)
-	requestURL := "https://raw.githubusercontent.com/scaleway/docs-content/refs/heads/main/pages/object-storage/how-to/create-a-bucket.mdx"
+	requestURL := "https://api.scaleway.com/product-catalog/v2alpha1/public-catalog/products?product_types=object_storage"
 	res, err := http.Get(requestURL)
 	if err != nil {
 		return nil, err
@@ -23,10 +40,18 @@ func GetRegionsScaleway() ([]string, error) {
 	if bErr != nil {
 		return nil, bErr
 	}
-
-	var regions []string
-	for _, a := range re.FindAllSubmatch(bytes, -1) {
-		regions = append(regions, string(a[1]))
+	resp := ProductsResponse{}
+	unmarshalErr := json.Unmarshal(bytes, &resp)
+	if unmarshalErr != nil {
+		return nil, err
 	}
+
+	regions := []string{}
+	for _, product := range resp.Products {
+		if product.ProductCategory == "Object Storage" && product.ProductName == "Standard One Zone" {
+			regions = append(regions, product.Locality.Region)
+		}
+	}
+
 	return regions, nil
 }

--- a/provider/digitalocean_test.go
+++ b/provider/digitalocean_test.go
@@ -25,7 +25,7 @@ func TestScanBucketPermissions_DO(t *testing.T) {
 	assert.Equal(t, bucket.PermissionDenied, c2.PermAllUsersRead)
 
 	// Bucket exists and has READ open
-	o := bucket.NewBucket("stats")
+	o := bucket.NewBucket("advertising")
 	o2, oErr := do.BucketExists(&o)
 	assert.Nil(t, oErr)
 	oScanErr := do.Scan(o2, true)

--- a/provider/providers.go
+++ b/provider/providers.go
@@ -45,16 +45,16 @@ var AllProviders = []string{
 }
 
 var ProviderRegions = map[string][]string{
-	"digitalocean": {"ams3", "atl1", "blr1", "fra1", "lon1", "nyc3", "sfo2", "sfo3", "sgp1", "syd1", "tor1"},
+	"digitalocean": {"ams3", "atl1", "blr1", "fra1", "lon1", "nyc3", "ric1", "sfo2", "sfo3", "sgp1", "syd1", "tor1"},
 	"dreamhost":    {"us-east-1"},
 	"linode": {"us-east-1", "us-ord-1", "us-lax-1", "us-sea-1", "us-southeast-1", "us-mia-1", "us-sea-9",
 		"us-iad-1", "us-iad-10", "id-cgk-1", "in-maa-1", "in-bom-1", "jp-osa-1", "jp-tyo-1", "ap-south-1", "sg-sin-1",
 		"eu-central-1", "de-fra-1", "es-mad-1", "fr-par-1", "gb-lon-1", "it-mil-1", "nl-ams-1", "se-sto-1",
-		"au-mel-1", "br-gru-1", "us-lax-4", "us-ord-10"},
-	"scaleway": {"fr-par", "nl-ams", "pl-waw"},
+		"au-mel-1", "br-gru-1", "us-lax-4", "us-ord-10", "fr-par-13", "us-iad-18"},
+	"scaleway": {"fr-par", "it-mil", "nl-ams", "pl-waw"},
 	"wasabi": {"us-west-1", "us-east-1", "us-east-2", "us-central-1", "ca-central-1", "eu-west-1", "eu-west-2",
 		"eu-west-3", "eu-central-1", "eu-central-2", "eu-south-1", "ap-northeast-1", "ap-northeast-2", "ap-southeast-2",
-		"ap-southeast-1"},
+		"ap-southeast-1", "us-west-2"},
 }
 
 func NewProvider(name string) (StorageProvider, error) {

--- a/provider/providers_test.go
+++ b/provider/providers_test.go
@@ -186,7 +186,7 @@ func Test_StorageProvider_Enum(t *testing.T) {
 		{name: "GCP", provider: providers["gcp"], goodBucket: bucket.NewBucket("assets"), numObjects: 3},
 		{name: "Linode", provider: providers["linode"], goodBucket: bucket.NewBucket("vantage"), numObjects: 51},
 		{name: "Scaleway", provider: providers["scaleway"], goodBucket: bucket.NewBucket("3d-builder"), numObjects: 1},
-		{name: "Wasabi", provider: providers["wasabi"], goodBucket: bucket.NewBucket("animals"), numObjects: 102},
+		{name: "Wasabi", provider: providers["wasabi"], goodBucket: bucket.NewBucket("appliance-repair"), numObjects: 34},
 	}
 
 	for _, tt := range tests {
@@ -194,11 +194,13 @@ func Test_StorageProvider_Enum(t *testing.T) {
 			t2.Parallel()
 			gb, err := tt.provider.BucketExists(&tt.goodBucket)
 			assert.Nil(t2, err)
+			if !assert.Equal(t2, bucket.BucketExists, gb.Exists, "expected bucket to exist but it does not") {
+				return
+			}
 			err = tt.provider.Scan(&tt.goodBucket, false)
 			assert.Nil(t2, err)
 			scanErr := tt.provider.Enumerate(gb)
 			assert.Nil(t2, scanErr)
-			assert.Equal(t2, bucket.BucketExists, gb.Exists)
 			assert.Equal(t2, int32(tt.numObjects), gb.NumObjects)
 		})
 	}
@@ -220,7 +222,7 @@ func Test_StorageProvider_Scan(t *testing.T) {
 		{name: "GCP", provider: providers["gcp"], bucket: bucket.NewBucket("hatrioua"), permissions: "AuthUsers: [] | AllUsers: []"},
 		{name: "Linode", provider: providers["linode"], bucket: bucket.NewBucket("vantage"), permissions: "AuthUsers: [] | AllUsers: [READ]"},
 		{name: "Scaleway", provider: providers["scaleway"], bucket: bucket.NewBucket("3d-builder"), permissions: "AuthUsers: [] | AllUsers: [READ]"},
-		{name: "Wasabi", provider: providers["wasabi"], bucket: bucket.NewBucket("acceptance"), permissions: "AuthUsers: [] | AllUsers: [READ, READ_ACP]"},
+		{name: "Wasabi", provider: providers["wasabi"], bucket: bucket.NewBucket("appliance-repair"), permissions: "AuthUsers: [] | AllUsers: [READ]"},
 	}
 
 	for _, tt := range tests {

--- a/provider/providers_test.go
+++ b/provider/providers_test.go
@@ -179,9 +179,9 @@ func Test_StorageProvider_Enum(t *testing.T) {
 		numObjects int
 	}{
 		{name: "AWS", provider: providers["aws"], goodBucket: bucket.NewBucket("s3scanner-empty"), numObjects: 0},
-		{name: "Custom public-read", provider: providers["custom"], goodBucket: bucket.NewBucket("alicante"), numObjects: 209},
+		{name: "Custom public-read", provider: providers["custom"], goodBucket: bucket.NewBucket("alicante"), numObjects: 210},
 		{name: "Custom no public-read", provider: providers["custom"], goodBucket: bucket.NewBucket("assets"), numObjects: 0},
-		{name: "DO", provider: providers["digitalocean"], goodBucket: bucket.NewBucket("action"), numObjects: 4},
+		{name: "DO", provider: providers["digitalocean"], goodBucket: bucket.NewBucket("action"), numObjects: 5},
 		{name: "Dreamhost", provider: providers["dreamhost"], goodBucket: bucket.NewBucket("acc"), numObjects: 310},
 		{name: "GCP", provider: providers["gcp"], goodBucket: bucket.NewBucket("assets"), numObjects: 3},
 		{name: "Linode", provider: providers["linode"], goodBucket: bucket.NewBucket("vantage"), numObjects: 51},

--- a/provider/providers_test.go
+++ b/provider/providers_test.go
@@ -149,7 +149,8 @@ func Test_StorageProvider_BucketExists(t *testing.T) {
 	}{
 		{name: "AWS", provider: providers["aws"], goodBucket: bucket.NewBucket("s3scanner-empty"), badBucket: bucket.NewBucket("s3scanner-no-exist")},
 		{name: "DO", provider: providers["digitalocean"], goodBucket: bucket.NewBucket("logo"), badBucket: bucket.NewBucket("s3scanner-no-exist")},
-		{name: "Dreamhost", provider: providers["dreamhost"], goodBucket: bucket.NewBucket("images"), badBucket: bucket.NewBucket("s3scanner-no-exist")},
+		// todo: fix Dreamhost and re-enable test. See #456
+		//{name: "Dreamhost", provider: providers["dreamhost"], goodBucket: bucket.NewBucket("images"), badBucket: bucket.NewBucket("s3scanner-no-exist")},
 		{name: "GCP", provider: providers["gcp"], goodBucket: bucket.NewBucket("books"), badBucket: bucket.NewBucket("s3scanner-no-exist")},
 		{name: "Linode", provider: providers["linode"], goodBucket: bucket.NewBucket("vantage"), badBucket: bucket.NewBucket("s3scanner-no-exist")},
 		{name: "Scaleway", provider: providers["scaleway"], goodBucket: bucket.NewBucket("2017"), badBucket: bucket.NewBucket("s3scanner-no-exist")},
@@ -177,12 +178,13 @@ func Test_StorageProvider_Enum(t *testing.T) {
 		provider   StorageProvider
 		goodBucket bucket.Bucket
 		numObjects int
+		skip       string
 	}{
 		{name: "AWS", provider: providers["aws"], goodBucket: bucket.NewBucket("s3scanner-empty"), numObjects: 0},
 		{name: "Custom public-read", provider: providers["custom"], goodBucket: bucket.NewBucket("alicante"), numObjects: 210},
 		{name: "Custom no public-read", provider: providers["custom"], goodBucket: bucket.NewBucket("assets"), numObjects: 0},
 		{name: "DO", provider: providers["digitalocean"], goodBucket: bucket.NewBucket("action"), numObjects: 5},
-		{name: "Dreamhost", provider: providers["dreamhost"], goodBucket: bucket.NewBucket("acc"), numObjects: 310},
+		//{name: "Dreamhost", provider: providers["dreamhost"], goodBucket: bucket.NewBucket("acc"), numObjects: 310},
 		{name: "GCP", provider: providers["gcp"], goodBucket: bucket.NewBucket("assets"), numObjects: 3},
 		{name: "Linode", provider: providers["linode"], goodBucket: bucket.NewBucket("vantage"), numObjects: 51},
 		{name: "Scaleway", provider: providers["scaleway"], goodBucket: bucket.NewBucket("3d-builder"), numObjects: 1},
@@ -192,6 +194,9 @@ func Test_StorageProvider_Enum(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t2 *testing.T) {
 			t2.Parallel()
+			if tt.skip != "" {
+				t2.Skip(tt.skip)
+			}
 			gb, err := tt.provider.BucketExists(&tt.goodBucket)
 			assert.Nil(t2, err)
 			if !assert.Equal(t2, bucket.BucketExists, gb.Exists, "expected bucket to exist but it does not") {
@@ -218,7 +223,7 @@ func Test_StorageProvider_Scan(t *testing.T) {
 		{name: "Custom public-read-write", provider: providers["custom"], bucket: bucket.NewBucket("nurse-virtual-assistants"), permissions: "AuthUsers: [] | AllUsers: []"},
 		{name: "Custom no public-read", provider: providers["custom"], bucket: bucket.NewBucket("assets"), permissions: "AuthUsers: [] | AllUsers: []"},
 		{name: "DO", provider: providers["digitalocean"], bucket: bucket.NewBucket("logo"), permissions: "AuthUsers: [] | AllUsers: [READ]"},
-		{name: "Dreamhost", provider: providers["dreamhost"], bucket: bucket.NewBucket("acc"), permissions: "AuthUsers: [] | AllUsers: [READ]"},
+		//{name: "Dreamhost", provider: providers["dreamhost"], bucket: bucket.NewBucket("acc"), permissions: "AuthUsers: [] | AllUsers: [READ]"},
 		{name: "GCP", provider: providers["gcp"], bucket: bucket.NewBucket("3d-printer"), permissions: "AuthUsers: [] | AllUsers: [READ]"},
 		{name: "Linode", provider: providers["linode"], bucket: bucket.NewBucket("vantage"), permissions: "AuthUsers: [] | AllUsers: [READ]"},
 		{name: "Scaleway", provider: providers["scaleway"], bucket: bucket.NewBucket("3d-builder"), permissions: "AuthUsers: [] | AllUsers: [READ]"},
@@ -227,10 +232,11 @@ func Test_StorageProvider_Scan(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t2 *testing.T) {
+
 			t2.Parallel()
 			gb, err := tt.provider.BucketExists(&tt.bucket)
-			scanErr := tt.provider.Scan(gb, false)
 			assert.Nil(t2, err)
+			scanErr := tt.provider.Scan(gb, false)
 			assert.Nil(t2, scanErr)
 			assert.Equal(t2, bucket.BucketExists, gb.Exists)
 			assert.Equal(t2, tt.permissions, tt.bucket.String())

--- a/provider/providers_test.go
+++ b/provider/providers_test.go
@@ -232,7 +232,6 @@ func Test_StorageProvider_Scan(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t2 *testing.T) {
-
 			t2.Parallel()
 			gb, err := tt.provider.BucketExists(&tt.bucket)
 			assert.Nil(t2, err)

--- a/provider/providers_test.go
+++ b/provider/providers_test.go
@@ -219,7 +219,7 @@ func Test_StorageProvider_Scan(t *testing.T) {
 		{name: "Custom no public-read", provider: providers["custom"], bucket: bucket.NewBucket("assets"), permissions: "AuthUsers: [] | AllUsers: []"},
 		{name: "DO", provider: providers["digitalocean"], bucket: bucket.NewBucket("logo"), permissions: "AuthUsers: [] | AllUsers: [READ]"},
 		{name: "Dreamhost", provider: providers["dreamhost"], bucket: bucket.NewBucket("acc"), permissions: "AuthUsers: [] | AllUsers: [READ]"},
-		{name: "GCP", provider: providers["gcp"], bucket: bucket.NewBucket("hatrioua"), permissions: "AuthUsers: [] | AllUsers: []"},
+		{name: "GCP", provider: providers["gcp"], bucket: bucket.NewBucket("3d-printer"), permissions: "AuthUsers: [] | AllUsers: [READ]"},
 		{name: "Linode", provider: providers["linode"], bucket: bucket.NewBucket("vantage"), permissions: "AuthUsers: [] | AllUsers: [READ]"},
 		{name: "Scaleway", provider: providers["scaleway"], bucket: bucket.NewBucket("3d-builder"), permissions: "AuthUsers: [] | AllUsers: [READ]"},
 		{name: "Wasabi", provider: providers["wasabi"], bucket: bucket.NewBucket("appliance-repair"), permissions: "AuthUsers: [] | AllUsers: [READ]"},

--- a/provider/wasabi_test.go
+++ b/provider/wasabi_test.go
@@ -1,9 +1,10 @@
 package provider
 
 import (
+	"testing"
+
 	"github.com/sa7mon/s3scanner/bucket"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestWasabi_NewExistsClient(t *testing.T) {
@@ -27,4 +28,9 @@ func TestWasabi_BucketExists(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, bucket.BucketExists, exists.Exists)
 	assert.Equal(t, "us-east-1", exists.Region)
+
+	// no such bucket
+	exists, err = w.BucketExists(&bucket.Bucket{Name: "helmet-rocket-trinket"})
+	assert.Nil(t, err)
+	assert.Equal(t, bucket.BucketNotExist, exists.Exists)
 }


### PR DESCRIPTION
# Summary

Update regions, region checks, and test buckets. Temporarily disable Dreamhost tests as scanning is broken (#456).

## Region Changes
- DigitalOcean: added `ric1`
- Linode: added `fr-par-13` and `us-iad-18`
- Scaleway: added `it-mil`
- Wasabi: added `us-west-2`

## Regioncheck Changes

- Scaleway: replaced the fragile regex scrape of a docs-content markdown file on GitHub with the official Scaleway product catalog API
- DigitalOcean: updated the row-header match from Spaces to Spaces Standard Storage to follow a change in product availability matrix
- Linode: pointed the scraper at Akamai's new endpoint-types docs page and updated the table selectors accordingly

## Test Fixes

- Replaced test buckets that no longer exist or whose contents changed (DigitalOcean, GCP, Wasabi) and updated expected object counts and permissions
- Temporarily disabled Dreamhost tests pending a fix (see #456)
- Added a negative BucketExists test for Wasabi
- Made `Test_StorageProvider_Enum` fail fast with a clear message when a bucket unexpectedly doesn't exist, and fixed an assertion-ordering issue in Test_StorageProvider_Scan where the scan ran before the existence error was checked
- Discovered #455 while fixing Wasabi tests
